### PR TITLE
Refactor task progress display

### DIFF
--- a/lib/providers/task_state.dart
+++ b/lib/providers/task_state.dart
@@ -11,6 +11,9 @@ class TaskInfo {
   final String message;
   final DateTime startTime;
   DateTime? endTime;
+  final int currentStep;
+  final int totalSteps;
+  final double? stepProgress;
 
   TaskInfo({
     required this.taskId,
@@ -21,6 +24,9 @@ class TaskInfo {
     required this.message,
     required this.startTime,
     this.endTime,
+    required this.currentStep,
+    required this.totalSteps,
+    this.stepProgress,
   });
 
   TaskInfo copyWith({
@@ -29,6 +35,9 @@ class TaskInfo {
     double? totalProgress,
     String? message,
     DateTime? endTime,
+    int? currentStep,
+    int? totalSteps,
+    double? stepProgress,
   }) {
     return TaskInfo(
       taskId: taskId,
@@ -39,6 +48,9 @@ class TaskInfo {
       message: message ?? this.message,
       startTime: startTime,
       endTime: endTime ?? this.endTime,
+      currentStep: currentStep ?? this.currentStep,
+      totalSteps: totalSteps ?? this.totalSteps,
+      stepProgress: stepProgress ?? this.stepProgress,
     );
   }
 
@@ -71,6 +83,9 @@ class TaskState extends ChangeNotifier {
           status: progress.status,
           totalProgress: progress.totalProgress,
           message: progress.message,
+          currentStep: progress.step.toInt(),
+          totalSteps: progress.totalSteps.toInt(),
+          stepProgress: progress.stepProgress,
           endTime: progress.status == TaskStatus.completed ||
                   progress.status == TaskStatus.failed ||
                   progress.status == TaskStatus.cancelled
@@ -102,6 +117,9 @@ class TaskState extends ChangeNotifier {
           totalProgress: progress.totalProgress,
           message: progress.message,
           startTime: DateTime.now(),
+          currentStep: progress.step.toInt(),
+          totalSteps: progress.totalSteps.toInt(),
+          stepProgress: progress.stepProgress,
         );
 
         debugPrint(

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -1532,6 +1532,12 @@ abstract class AppLocalizations {
   /// **'Unknown'**
   String get taskUnknown;
 
+  /// No description provided for @taskStep.
+  ///
+  /// In en, this message translates to:
+  /// **'Step {current} of {total}'**
+  String taskStep(int current, int total);
+
   /// No description provided for @backupOptionsTitle.
   ///
   /// In en, this message translates to:

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -773,6 +773,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get taskUnknown => 'Unknown';
 
   @override
+  String taskStep(int current, int total) {
+    return 'Step $current of $total';
+  }
+
+  @override
   String get backupOptionsTitle => 'Backup Options';
 
   @override

--- a/lib/src/l10n/app_localizations_ru.dart
+++ b/lib/src/l10n/app_localizations_ru.dart
@@ -780,6 +780,11 @@ class AppLocalizationsRu extends AppLocalizations {
   String get taskUnknown => 'Неизвестно';
 
   @override
+  String taskStep(int current, int total) {
+    return 'Шаг $current из $total';
+  }
+
+  @override
   String get backupOptionsTitle => 'Параметры резервного копирования';
 
   @override

--- a/lib/widgets/common/status_bar.dart
+++ b/lib/widgets/common/status_bar.dart
@@ -159,7 +159,7 @@ class StatusBar extends StatelessWidget {
     final recentTasks = taskState.recentTasks;
     final hasActiveTasks = activeTasks.isNotEmpty;
     final hasRecentTasks = recentTasks.isNotEmpty;
-    final progress = hasActiveTasks ? activeTasks.first.totalProgress : null;
+    final progress = hasActiveTasks ? activeTasks.first.stepProgress : null;
 
     return Material(
       color: Colors.transparent,

--- a/lib/widgets/dialogs/task_list_dialog.dart
+++ b/lib/widgets/dialogs/task_list_dialog.dart
@@ -213,11 +213,22 @@ class _TaskListDialogState extends State<TaskListDialog>
                   ),
                 ),
               ),
+              const SizedBox(width: 8),
+              Text(
+                l10n.taskStep(task.currentStep, task.totalSteps),
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.7),
+                ),
+              ),
             ],
           ),
           if (!task.isFinished)
             LinearProgressIndicator(
-              value: task.totalProgress,
+              value: task.stepProgress,
               backgroundColor: Colors.grey.withValues(alpha: 0.1),
             ),
         ],
@@ -227,8 +238,10 @@ class _TaskListDialogState extends State<TaskListDialog>
           : Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text('${(task.totalProgress * 100).toInt()}%'),
-                const SizedBox(width: 4),
+                if (task.stepProgress != null) ...[
+                  Text('${(task.stepProgress! * 100).toInt()}%'),
+                  const SizedBox(width: 4),
+                ],
                 // TODO: disable button when task is not cancellable
                 IconButton(
                   visualDensity: VisualDensity.compact,

--- a/native/hub/src/models/signals/task.rs
+++ b/native/hub/src/models/signals/task.rs
@@ -75,4 +75,7 @@ pub struct TaskProgress {
     pub status: TaskStatus,
     pub total_progress: f32,
     pub message: String,
+    pub step: u32,
+    pub total_steps: u32,
+    pub step_progress: Option<f32>,
 }


### PR DESCRIPTION
## Summary
- track step-aware task progress in backend signals
- display current step progress with step counts and indeterminate steps
- expose step info in UI and localizations

## Testing
- `just gen` *(fails: rinf: not found)*
- `cargo +nightly fmt`
- `dart format .` *(fails: dart: not found)*
- `flutter analyze` *(fails: flutter: not found)*
- `just test`

------
https://chatgpt.com/codex/tasks/task_b_68c3e3ad2638832d9e09f8d5c78105c1