### PR TITLE
Refactor task progress display [cli]

### DIFF
--- a/lib/providers/task_state.dart
+++ b/lib/providers/task_state.dart
@@ -8,6 +8,9 @@ class TaskInfo {
   final String? taskName;
   final TaskStatus status;
   final double totalProgress;
+  final int currentStep;
+  final int totalSteps;
+  final double? stepProgress;
   final String message;
   final DateTime startTime;
   DateTime? endTime;
@@ -18,6 +21,9 @@ class TaskInfo {
     this.taskName,
     required this.status,
     required this.totalProgress,
+    required this.currentStep,
+    required this.totalSteps,
+    required this.stepProgress,
     required this.message,
     required this.startTime,
     this.endTime,
@@ -27,6 +33,9 @@ class TaskInfo {
     String? taskName,
     TaskStatus? status,
     double? totalProgress,
+    int? currentStep,
+    int? totalSteps,
+    double? Function()? stepProgress,
     String? message,
     DateTime? endTime,
   }) {
@@ -36,6 +45,9 @@ class TaskInfo {
       taskName: taskName ?? this.taskName,
       status: status ?? this.status,
       totalProgress: totalProgress ?? this.totalProgress,
+      currentStep: currentStep ?? this.currentStep,
+      totalSteps: totalSteps ?? this.totalSteps,
+      stepProgress: stepProgress == null ? this.stepProgress : stepProgress(),
       message: message ?? this.message,
       startTime: startTime,
       endTime: endTime ?? this.endTime,
@@ -70,6 +82,9 @@ class TaskState extends ChangeNotifier {
           taskName: progress.taskName,
           status: progress.status,
           totalProgress: progress.totalProgress,
+          currentStep: progress.currentStep,
+          totalSteps: progress.totalSteps,
+          stepProgress: () => progress.stepProgress,
           message: progress.message,
           endTime: progress.status == TaskStatus.completed ||
                   progress.status == TaskStatus.failed ||
@@ -100,6 +115,9 @@ class TaskState extends ChangeNotifier {
           taskName: progress.taskName,
           status: progress.status,
           totalProgress: progress.totalProgress,
+          currentStep: progress.currentStep,
+          totalSteps: progress.totalSteps,
+          stepProgress: progress.stepProgress,
           message: progress.message,
           startTime: DateTime.now(),
         );

--- a/lib/widgets/common/status_bar.dart
+++ b/lib/widgets/common/status_bar.dart
@@ -159,7 +159,7 @@ class StatusBar extends StatelessWidget {
     final recentTasks = taskState.recentTasks;
     final hasActiveTasks = activeTasks.isNotEmpty;
     final hasRecentTasks = recentTasks.isNotEmpty;
-    final progress = hasActiveTasks ? activeTasks.first.totalProgress : null;
+    final progress = hasActiveTasks ? activeTasks.first.stepProgress : null;
 
     return Material(
       color: Colors.transparent,

--- a/lib/widgets/dialogs/task_list_dialog.dart
+++ b/lib/widgets/dialogs/task_list_dialog.dart
@@ -213,11 +213,24 @@ class _TaskListDialogState extends State<TaskListDialog>
                   ),
                 ),
               ),
+              if (!task.isFinished) ...[
+                const SizedBox(width: 8),
+                Text(
+                  '${task.currentStep}/${task.totalSteps}',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.6),
+                  ),
+                ),
+              ],
             ],
           ),
           if (!task.isFinished)
             LinearProgressIndicator(
-              value: task.totalProgress,
+              value: task.stepProgress, // null -> indeterminate
               backgroundColor: Colors.grey.withValues(alpha: 0.1),
             ),
         ],
@@ -227,7 +240,8 @@ class _TaskListDialogState extends State<TaskListDialog>
           : Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text('${(task.totalProgress * 100).toInt()}%'),
+                if (task.stepProgress != null)
+                  Text('${(task.stepProgress! * 100).toInt()}%'),
                 const SizedBox(width: 4),
                 // TODO: disable button when task is not cancellable
                 IconButton(

--- a/native/hub/src/lib.rs
+++ b/native/hub/src/lib.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use downloader::Downloader;
 use logging::SignalLayer;
 use mimalloc::MiMalloc;
-use models::signals::system::{RustPanic, MediaConfigChanged};
+use models::signals::system::{MediaConfigChanged, RustPanic};
 use rinf::RustSignal;
 use settings::SettingsHandler;
 use task::TaskManager;
@@ -70,11 +70,8 @@ async fn main() {
         rinf::debug_print!("Failed to create media cache directory: {:#}", e);
     }
     let media_base_url = "https://webdav.5698452.xyz/media/".to_string();
-    MediaConfigChanged {
-        media_base_url,
-        cache_dir: media_cache_dir.display().to_string(),
-    }
-    .send_signal_to_dart();
+    MediaConfigChanged { media_base_url, cache_dir: media_cache_dir.display().to_string() }
+        .send_signal_to_dart();
 
     let adb_handler = AdbHandler::new(WatchStream::new(settings_handler.subscribe())).await;
     let downloader = Downloader::new(WatchStream::new(settings_handler.subscribe())).await;

--- a/native/hub/src/models/signals/task.rs
+++ b/native/hub/src/models/signals/task.rs
@@ -73,6 +73,15 @@ pub struct TaskProgress {
     pub task_type: TaskType,
     pub task_name: Option<String>,
     pub status: TaskStatus,
+    /// Overall progress across all steps in range [0.0, 1.0]
     pub total_progress: f32,
+    /// Human-readable status for the current step
     pub message: String,
+    /// 1-based index of the current step being executed
+    pub current_step: u32,
+    /// Total number of steps for this task
+    pub total_steps: u32,
+    /// Progress for the current step in range [0.0, 1.0].
+    /// None means this step does not report progress (show indeterminate).
+    pub step_progress: Option<f32>,
 }

--- a/native/hub/src/models/signals/task.rs
+++ b/native/hub/src/models/signals/task.rs
@@ -77,11 +77,9 @@ pub struct TaskProgress {
     pub total_progress: f32,
     /// Human-readable status for the current step
     pub message: String,
-    /// 1-based index of the current step being executed
     pub current_step: u32,
-    /// Total number of steps for this task
     pub total_steps: u32,
     /// Progress for the current step in range [0.0, 1.0].
-    /// None means this step does not report progress (show indeterminate).
+    /// None means this step does not report progress.
     pub step_progress: Option<f32>,
 }

--- a/native/hub/src/task.rs
+++ b/native/hub/src/task.rs
@@ -237,6 +237,9 @@ impl TaskManager {
                     TaskStatus::Failed,
                     0.0,
                     format!("Failed to initialize task: {e:#}"),
+                    1,
+                    1,
+                    None,
                 );
 
                 // Log task cleanup
@@ -251,18 +254,41 @@ impl TaskManager {
             }
         };
 
-        let update_progress = |status: TaskStatus, progress: f32, message: String| {
-            // debug!(
-            //     task_id = id,
-            //     status = ?status,
-            //     progress = progress,
-            //     message = %message,
-            //     "Task progress update"
-            // ); // TODO: limit logging frequency
-            send_progress(id, task_type, Some(task_name.clone()), status, progress, message);
+        // Define step-aware progress reporting
+        let total_steps: u32 = match task_type {
+            TaskType::DownloadInstall => 2,
+            _ => 1,
         };
 
-        update_progress(TaskStatus::Waiting, 0.0, "Starting...".into());
+        let update_progress =
+            |status: TaskStatus, step_index: u32, step_progress: Option<f32>, message: String| {
+                // debug!(
+                //     task_id = id,
+                //     status = ?status,
+                //     step_index = step_index,
+                //     step_progress = ?step_progress,
+                //     message = %message,
+                //     "Task progress update"
+                // ); // TODO: limit logging frequency
+                let safe_total = total_steps.max(1) as f32;
+                let completed_steps = step_index.saturating_sub(1) as f32;
+                let sp = step_progress.unwrap_or(0.0).clamp(0.0, 1.0);
+                let total_progress = (completed_steps + sp) / safe_total;
+
+                send_progress(
+                    id,
+                    task_type,
+                    Some(task_name.clone()),
+                    status,
+                    total_progress,
+                    message,
+                    step_index,
+                    total_steps,
+                    step_progress,
+                );
+            };
+
+        update_progress(TaskStatus::Waiting, 1, None, "Starting...".into());
 
         Toast::send(
             task_name.clone(),
@@ -313,7 +339,7 @@ impl TaskManager {
                     duration_secs = duration.as_secs_f64(),
                     "Task completed successfully"
                 );
-                update_progress(TaskStatus::Completed, 1.0, "Done".into());
+                update_progress(TaskStatus::Completed, total_steps, Some(1.0), "Done".into());
                 Toast::send(task_name, format!("{task_type}: completed"), false, None);
             }
             Err(e) => {
@@ -324,7 +350,12 @@ impl TaskManager {
                         duration_ms = duration.as_millis(),
                         "Task was cancelled by user"
                     );
-                    update_progress(TaskStatus::Cancelled, 0.0, "Task cancelled by user".into());
+                    update_progress(
+                        TaskStatus::Cancelled,
+                        total_steps,
+                        None,
+                        "Task cancelled by user".into(),
+                    );
                     Toast::send(task_name, format!("{task_type}: cancelled"), false, None);
                 } else {
                     error!(
@@ -335,7 +366,12 @@ impl TaskManager {
                         error_chain = ?e.chain().collect::<Vec<_>>(),
                         "Task failed with error"
                     );
-                    update_progress(TaskStatus::Failed, 0.0, format!("Task failed: {e:#}"));
+                    update_progress(
+                        TaskStatus::Failed,
+                        total_steps,
+                        None,
+                        format!("Task failed: {e:#}"),
+                    );
                     Toast::send(
                         task_name,
                         format!("{task_type}: failed"),
@@ -359,7 +395,7 @@ impl TaskManager {
     async fn handle_download_install(
         &self,
         params: TaskParams,
-        update_progress: &impl Fn(TaskStatus, f32, String),
+        update_progress: &impl Fn(TaskStatus, u32, Option<f32>, String),
         token: CancellationToken,
     ) -> Result<()> {
         let app_full_name =
@@ -372,7 +408,7 @@ impl TaskManager {
             "Starting download and install task"
         );
 
-        update_progress(TaskStatus::Waiting, 0.0, "Waiting to start download...".into());
+        update_progress(TaskStatus::Waiting, 1, None, "Waiting to start download...".into());
 
         let _download_permit =
             acquire_permit_or_cancel!(self.download_semaphore, token, "download");
@@ -381,7 +417,7 @@ impl TaskManager {
             "Acquired download semaphore"
         );
 
-        update_progress(TaskStatus::Running, 0.0, "Starting download...".into());
+        update_progress(TaskStatus::Running, 1, None, "Starting download...".into());
 
         let (tx, mut rx) = mpsc::unbounded_channel::<RcloneTransferStats>();
 
@@ -431,8 +467,13 @@ impl TaskManager {
 
                     update_progress(
                         TaskStatus::Running,
-                        step_progress * 0.5, // Scaling to 1/2 to get total
-                        format!("Downloading ({:.1}%) - {}/s", step_progress * 100.0, humansize::format_size(progress.speed, humansize::DECIMAL)),
+                        1,
+                        Some(step_progress),
+                        format!(
+                            "Downloading ({:.1}%) - {}/s",
+                            step_progress * 100.0,
+                            humansize::format_size(progress.speed, humansize::DECIMAL)
+                        ),
                     );
                 }
             }
@@ -451,7 +492,7 @@ impl TaskManager {
             return Err(anyhow!("Task cancelled after download"));
         }
 
-        update_progress(TaskStatus::Waiting, 0.5, "Waiting to start installation...".into());
+        update_progress(TaskStatus::Waiting, 2, None, "Waiting to start installation...".into());
 
         let _adb_permit = acquire_permit_or_cancel!(self.adb_semaphore, token, "ADB");
         info!(
@@ -459,7 +500,7 @@ impl TaskManager {
             "Acquired ADB semaphore for installation"
         );
 
-        update_progress(TaskStatus::Running, 0.75, "Installing app...".into());
+        update_progress(TaskStatus::Running, 2, None, "Installing app...".into());
 
         // self.adb_handler.sideload_app(Path::new(&app_path)).await?;
 
@@ -498,7 +539,7 @@ impl TaskManager {
                         last_sideload_log = now;
                     }
 
-                    update_progress(TaskStatus::Running, 0.75 + step_progress * 0.25, progress.status);
+                    update_progress(TaskStatus::Running, 2, Some(step_progress), progress.status);
                 }
             }
         }
@@ -517,7 +558,7 @@ impl TaskManager {
     async fn handle_download(
         &self,
         params: TaskParams,
-        update_progress: &impl Fn(TaskStatus, f32, String),
+        update_progress: &impl Fn(TaskStatus, u32, Option<f32>, String),
         token: CancellationToken,
     ) -> Result<()> {
         let app_full_name =
@@ -529,7 +570,7 @@ impl TaskManager {
             "Starting download task"
         );
 
-        update_progress(TaskStatus::Waiting, 0.0, "Waiting to start download...".into());
+        update_progress(TaskStatus::Waiting, 1, None, "Waiting to start download...".into());
 
         let _permit = acquire_permit_or_cancel!(self.download_semaphore, token, "download");
         info!(
@@ -537,7 +578,7 @@ impl TaskManager {
             "Acquired download semaphore"
         );
 
-        update_progress(TaskStatus::Running, 0.0, "Starting download...".into());
+        update_progress(TaskStatus::Running, 1, None, "Starting download...".into());
 
         let (tx, mut rx) = mpsc::unbounded_channel::<RcloneTransferStats>();
 
@@ -583,8 +624,13 @@ impl TaskManager {
 
                     update_progress(
                         TaskStatus::Running,
-                        step_progress,
-                        format!("Downloading ({:.1}%) - {}/s", step_progress * 100.0, humansize::format_size(progress.speed, humansize::DECIMAL)),
+                        1,
+                        Some(step_progress),
+                        format!(
+                            "Downloading ({:.1}%) - {}/s",
+                            step_progress * 100.0,
+                            humansize::format_size(progress.speed, humansize::DECIMAL)
+                        ),
                     );
                 }
             }
@@ -604,7 +650,7 @@ impl TaskManager {
     async fn handle_install_apk(
         &self,
         params: TaskParams,
-        update_progress: &impl Fn(TaskStatus, f32, String),
+        update_progress: &impl Fn(TaskStatus, u32, Option<f32>, String),
         token: CancellationToken,
     ) -> Result<()> {
         let apk_path = params.apk_path.context("Missing apk_path parameter")?;
@@ -615,7 +661,7 @@ impl TaskManager {
             "Starting APK install task"
         );
 
-        update_progress(TaskStatus::Waiting, 0.0, "Waiting to start installation...".into());
+        update_progress(TaskStatus::Waiting, 1, None, "Waiting to start installation...".into());
 
         let _permit = acquire_permit_or_cancel!(self.adb_semaphore, token, "ADB");
         info!(
@@ -623,7 +669,7 @@ impl TaskManager {
             "Acquired ADB semaphore for APK installation"
         );
 
-        update_progress(TaskStatus::Running, 0.0, "Installing APK...".into());
+        update_progress(TaskStatus::Running, 1, None, "Installing APK...".into());
 
         let (tx, mut rx) = mpsc::unbounded_channel::<f32>();
 
@@ -659,7 +705,7 @@ impl TaskManager {
                         last_log_time = now;
                     }
 
-                    update_progress(TaskStatus::Running, step_progress, "Installing APK...".into());
+                    update_progress(TaskStatus::Running, 1, Some(step_progress), "Installing APK...".into());
                 }
             }
         }
@@ -677,7 +723,7 @@ impl TaskManager {
     async fn handle_install_local_app(
         &self,
         params: TaskParams,
-        update_progress: &impl Fn(TaskStatus, f32, String),
+        update_progress: &impl Fn(TaskStatus, u32, Option<f32>, String),
         token: CancellationToken,
     ) -> Result<()> {
         let app_path = params.local_app_path.context("Missing local_app_path parameter")?;
@@ -688,7 +734,7 @@ impl TaskManager {
             "Starting local app install task"
         );
 
-        update_progress(TaskStatus::Waiting, 0.0, "Waiting to start installation...".into());
+        update_progress(TaskStatus::Waiting, 1, None, "Waiting to start installation...".into());
 
         let _permit = acquire_permit_or_cancel!(self.adb_semaphore, token, "ADB");
         info!(
@@ -696,7 +742,7 @@ impl TaskManager {
             "Acquired ADB semaphore for local app installation"
         );
 
-        update_progress(TaskStatus::Running, 0.0, "Installing app...".into());
+        update_progress(TaskStatus::Running, 1, None, "Installing app...".into());
 
         // self.adb_handler.sideload_app(Path::new(&app_path)).await?;
 
@@ -735,7 +781,7 @@ impl TaskManager {
                         last_sideload_log = now;
                     }
 
-                    update_progress(TaskStatus::Running, step_progress, progress.status);
+                    update_progress(TaskStatus::Running, 1, Some(step_progress), progress.status);
                 }
             }
         }
@@ -754,7 +800,7 @@ impl TaskManager {
     async fn handle_uninstall(
         &self,
         params: TaskParams,
-        update_progress: &impl Fn(TaskStatus, f32, String),
+        update_progress: &impl Fn(TaskStatus, u32, Option<f32>, String),
         token: CancellationToken,
     ) -> Result<()> {
         let package_name = params.package_name.context("Missing package_name parameter")?;
@@ -765,7 +811,7 @@ impl TaskManager {
             "Starting uninstall task"
         );
 
-        update_progress(TaskStatus::Waiting, 0.0, "Waiting to start uninstallation...".into());
+        update_progress(TaskStatus::Waiting, 1, None, "Waiting to start uninstallation...".into());
 
         let _permit = acquire_permit_or_cancel!(self.adb_semaphore, token, "ADB");
         info!(
@@ -773,7 +819,7 @@ impl TaskManager {
             "Acquired ADB semaphore for uninstallation"
         );
 
-        update_progress(TaskStatus::Running, 0.0, "Uninstalling app...".into());
+        update_progress(TaskStatus::Running, 1, None, "Uninstalling app...".into());
 
         info!(package_name = %package_name, "Starting uninstall operation");
         self.adb_handler.uninstall_package(&package_name).await?;
@@ -791,7 +837,7 @@ impl TaskManager {
     async fn handle_backup(
         &self,
         params: TaskParams,
-        update_progress: &impl Fn(TaskStatus, f32, String),
+        update_progress: &impl Fn(TaskStatus, u32, Option<f32>, String),
         token: CancellationToken,
     ) -> Result<()> {
         let package_name = params.package_name.context("Missing package_name parameter")?;
@@ -808,7 +854,7 @@ impl TaskManager {
             "Starting backup task"
         );
 
-        update_progress(TaskStatus::Waiting, 0.0, "Waiting to start backup...".into());
+        update_progress(TaskStatus::Waiting, 1, None, "Waiting to start backup...".into());
 
         let _permit = acquire_permit_or_cancel!(self.adb_semaphore, token, "ADB");
         info!(
@@ -826,7 +872,7 @@ impl TaskManager {
         .collect::<Vec<_>>()
         .join(", ");
 
-        update_progress(TaskStatus::Running, 0.0, format!("Creating backup ({parts})..."));
+        update_progress(TaskStatus::Running, 1, None, format!("Creating backup ({parts})..."));
 
         let backups_dir = {
             let s = self.settings.read().await;
@@ -869,7 +915,7 @@ impl TaskManager {
     async fn handle_restore(
         &self,
         params: TaskParams,
-        update_progress: &impl Fn(TaskStatus, f32, String),
+        update_progress: &impl Fn(TaskStatus, u32, Option<f32>, String),
         token: CancellationToken,
     ) -> Result<()> {
         let backup_path = params.backup_path.context("Missing backup_path parameter")?;
@@ -880,7 +926,7 @@ impl TaskManager {
             "Starting restore task"
         );
 
-        update_progress(TaskStatus::Waiting, 0.0, "Waiting to start restore...".into());
+        update_progress(TaskStatus::Waiting, 1, None, "Waiting to start restore...".into());
 
         let _permit = acquire_permit_or_cancel!(self.adb_semaphore, token, "ADB");
         info!(
@@ -888,7 +934,7 @@ impl TaskManager {
             "Acquired ADB semaphore for restore"
         );
 
-        update_progress(TaskStatus::Running, 0.0, "Restoring backup...".into());
+        update_progress(TaskStatus::Running, 1, None, "Restoring backup...".into());
 
         self.adb_handler.restore_backup(Path::new(&backup_path)).await?;
 
@@ -908,6 +954,9 @@ fn send_progress(
     status: TaskStatus,
     total_progress: f32,
     message: String,
+    current_step: u32,
+    total_steps: u32,
+    step_progress: Option<f32>,
 ) {
     // Log significant status changes (not every progress update to avoid spam)
     match status {
@@ -937,8 +986,18 @@ fn send_progress(
         }
     }
 
-    TaskProgress { task_id, task_type, task_name, status, total_progress, message }
-        .send_signal_to_dart();
+    TaskProgress {
+        task_id,
+        task_type,
+        task_name,
+        status,
+        total_progress,
+        message,
+        current_step,
+        total_steps,
+        step_progress,
+    }
+    .send_signal_to_dart();
 }
 
 fn get_task_name(task_type: TaskType, params: &TaskParams) -> Result<String> {


### PR DESCRIPTION
Change summary:

  - Rust: Extended TaskProgress with step-aware
  fields (current_step, total_steps, step_progress)
  and wired them through send_progress and all
  task handlers. Overall progress is derived from
  step info; steps with no per-step reporting use
  indeterminate state.
  - Codegen: Regenerated Rinf bindings so Dart gets
  new fields.
  - Dart state: Updated TaskInfo and TaskState to
  store and update currentStep, totalSteps, and
  stepProgress.
  - UI:
      - Task list dialog: Shows “currentStep/
  totalSteps” next to the message. Progress bar now
  reflects stepProgress and is indeterminate when
  stepProgress is null. Percent text displays only
  for stepProgress.
      - Status bar: Circular progress now uses
  stepProgress (indeterminate when null) rather than
  totalProgress.
  - Formatting and analysis: Ran formatters and
  flutter analyze; no issues.

  What to expect:

  - For multi-step tasks (e.g., Download & Install),
  the dialog shows “1/2” during download, then
  “2/2” during install, with only the current step’s
  progress visible.
  - For single-step tasks that don’t report progress
  (e.g., uninstall/backup/restore), the progress bar
  is indeterminate, and step indicator shows “1/1”.
  - Status bar spinner uses the current step progress
  and becomes indeterminate when appropriate.