### PR TITLE
Add downloads cleanup policy

### DIFF
--- a/lib/widgets/screens/settings_screen.dart
+++ b/lib/widgets/screens/settings_screen.dart
@@ -233,18 +233,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
   }
 
-  // String _formatCleanupPolicy(
-  //         AppLocalizations l10n, DownloadCleanupPolicy policy) =>
-  //     switch (policy) {
-  //       DownloadCleanupPolicy.deleteAfterInstall =>
-  //         l10n.settingsCleanupDeleteAfterInstall,
-  //       DownloadCleanupPolicy.keepOneVersion =>
-  //         l10n.settingsCleanupKeepOneVersion,
-  //       DownloadCleanupPolicy.keepTwoVersions =>
-  //         l10n.settingsCleanupKeepTwoVersions,
-  //       DownloadCleanupPolicy.keepAllVersions =>
-  //         l10n.settingsCleanupKeepAllVersions,
-  //     };
+  String _formatCleanupPolicy(
+          AppLocalizations l10n, DownloadCleanupPolicy policy) =>
+      switch (policy) {
+        DownloadCleanupPolicy.deleteAfterInstall =>
+          l10n.settingsCleanupDeleteAfterInstall,
+        DownloadCleanupPolicy.keepOneVersion =>
+          l10n.settingsCleanupKeepOneVersion,
+        DownloadCleanupPolicy.keepTwoVersions =>
+          l10n.settingsCleanupKeepTwoVersions,
+        DownloadCleanupPolicy.keepAllVersions =>
+          l10n.settingsCleanupKeepAllVersions,
+      };
 
   // String _formatConnectionType(AppLocalizations l10n, ConnectionType type) =>
   //     switch (type) {
@@ -457,30 +457,22 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ),
           ),
-          // TODO: implement
-          // _buildDropdownSetting<DownloadCleanupPolicy>(
-          //   label: l10n.settingsDownloadsCleanup,
-          //   value: _currentFormSettings.cleanupPolicy,
-          //   items: DownloadCleanupPolicy.values.map((policy) {
-          //     return DropdownMenuItem(
-          //       value: policy,
-          //       child: Text(_formatCleanupPolicy(l10n, policy)),
-          //     );
-          //   }).toList(),
-          //   onChanged: (value) {
-          //     if (value != null) {
-          //       setState(() => _currentFormSettings =
-          //           _currentFormSettings.copyWith(cleanupPolicy: value));
-          //       _checkForChanges();
-          //     }
-          //   },
-          // ),
-          _buildDropdownSetting<DownloadCleanupPolicy?>(
+          _buildDropdownSetting<DownloadCleanupPolicy>(
             label: l10n.settingsDownloadsCleanup,
-            value: null,
-            items: [],
-            onChanged: null,
-            disabledHint: const Text('Not implemented'),
+            value: _currentFormSettings.cleanupPolicy,
+            items: DownloadCleanupPolicy.values.map((policy) {
+              return DropdownMenuItem(
+                value: policy,
+                child: Text(_formatCleanupPolicy(l10n, policy)),
+              );
+            }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => _currentFormSettings =
+                    _currentFormSettings.copyWith(cleanupPolicy: value));
+                _checkForChanges();
+              }
+            },
           ),
         ],
       ),

--- a/native/hub/src/downloader.rs
+++ b/native/hub/src/downloader.rs
@@ -134,6 +134,27 @@ impl Downloader {
         handle
     }
 
+    /// Returns the cached CloudApp (if any) that matches the given full name
+    pub async fn get_app_by_full_name(&self, full_name: &str) -> Option<CloudApp> {
+        let cache = self.cloud_apps.lock().await;
+        cache.iter().find(|a| a.full_name == full_name).cloned()
+    }
+
+    /// Returns all cached CloudApps for a given package name
+    pub async fn get_apps_by_package(&self, package_name: &str) -> Vec<CloudApp> {
+        let cache = self.cloud_apps.lock().await;
+        cache
+            .iter()
+            .filter(|a| a.package_name == package_name)
+            .cloned()
+            .collect()
+    }
+
+    /// Returns the current downloads directory
+    pub async fn get_download_dir(&self) -> PathBuf {
+        self.download_dir.read().await.clone()
+    }
+
     #[instrument(skip(self))]
     pub async fn receive_commands(&self) {
         let load_cloud_apps_receiver = LoadCloudAppsRequest::get_dart_signal_receiver();


### PR DESCRIPTION
Summary of changes:
- Implement downloads cleanup policy enforcement in Rust TaskManager
- Add helper APIs on Downloader to query cached apps and download dir
- Apply policy after successful Download & Install (Delete, Keep 1/2/All)
- Unlock Downloads Cleanup selector in Settings UI with localization

Areas touched:
- native/hub/src/task.rs
- native/hub/src/downloader.rs
- lib/widgets/screens/settings_screen.dart

Validation:
- cargo check + cargo test pass for native/hub
- flutter analyze shows no issues

Notes/Follow-ups:
- KeepOne/Two cleanup uses cached cloud apps to identify versions by package; unknown versions not in cache are left intact to be safe.
