### PR TITLE
Update file_picker

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:desktop_window/desktop_window.dart';
 import 'package:flutter/material.dart';
 import 'package:dynamic_color/dynamic_color.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:system_date_time_format/system_date_time_format.dart';
 import 'utils/theme_utils.dart' as app_theme;
 import 'package:provider/provider.dart';
@@ -26,6 +27,7 @@ import 'widgets/common/status_bar.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await FilePicker.skipEntitlementsChecks();
   await DesktopWindow.setMinWindowSize(const Size(800, 600));
 
   VideoPlayerMediaKit.ensureInitialized(

--- a/lib/widgets/screens/local_sideload_screen.dart
+++ b/lib/widgets/screens/local_sideload_screen.dart
@@ -59,10 +59,11 @@ class _LocalSideloadScreenState extends State<LocalSideloadScreen> {
     String? path;
     final l10n = AppLocalizations.of(context);
     if (_isDirectory) {
-      path = await FilePicker.platform
-          .getDirectoryPath(dialogTitle: l10n.selectAppDirectoryTitle);
+      path = await FilePicker.getDirectoryPath(
+        dialogTitle: l10n.selectAppDirectoryTitle,
+      );
     } else {
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         dialogTitle: l10n.selectApkFileTitle,
         type: FileType.custom,
         allowedExtensions: ['apk'],

--- a/lib/widgets/screens/settings_screen.dart
+++ b/lib/widgets/screens/settings_screen.dart
@@ -241,7 +241,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       initialDirectory = currentValue;
     }
 
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       dialogTitle: l10n.selectLabel(label),
       initialDirectory: initialDirectory,
     );
@@ -255,7 +255,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       initialDirectory = currentValue;
     }
 
-    return FilePicker.platform.getDirectoryPath(
+    return FilePicker.getDirectoryPath(
       dialogTitle: l10n.selectLabelDirectory(label),
       initialDirectory: initialDirectory,
     );
@@ -710,7 +710,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 const SizedBox(width: 8),
                 TextButton.icon(
                   onPressed: () async {
-                    final result = await FilePicker.platform.pickFiles(
+                    final result = await FilePicker.pickFiles(
                       dialogTitle: l10n.settingsSelectDownloaderConfig,
                       allowMultiple: false,
                       type: FileType.custom,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -180,12 +180,11 @@ packages:
   file_picker:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: cd5be752150c4c39f28ef4c4b5e1b698bf5b2509
-      url: "https://github.com/skrimix/flutter_file_picker.git"
-    source: git
-    version: "10.3.7"
+      name: file_picker
+      sha256: "84fd4edc420fd356b4c72b733ba3b54b4b20240b9e495e3852fe015181c9ede6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.1"
   filesize:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,10 +42,7 @@ dependencies:
   filesize: ^2.0.1
   proper_filesize: ^1.0.2
   toastification: ^2.3.0 # Updating to >=3.0.0 breaks text color
-  #file_picker: ^10.3.3
-  file_picker:
-    # Remove when this is fixed: https://github.com/miguelpruivo/flutter_file_picker/issues/1845
-    git: https://github.com/skrimix/flutter_file_picker.git
+  file_picker: 11.0.1
   intl: ^0.20.2
   desktop_window: ^0.4.2
   desktop_drop: ^0.6.1


### PR DESCRIPTION
### Motivation
- Revert the temporary git-sourced `file_picker` to the public `11.0.1` release to use the official package and simplify dependency management.
- Ensure macOS entitlements checks are skipped at startup where required by the plugin by calling the provided API.

### Description
- Update dependency in `pubspec.yaml` to `file_picker: 11.0.1` and refresh `pubspec.lock` to resolve from `pub.dev`.
- Import `package:file_picker/file_picker.dart` and call `await FilePicker.skipEntitlementsChecks();` in `main()` during app initialization.
- Migrate existing call sites from the instance API (`FilePicker.platform.pickFiles` / `FilePicker.platform.getDirectoryPath`) to the v11 static API (`FilePicker.pickFiles` / `FilePicker.getDirectoryPath`) in `lib/widgets/screens/local_sideload_screen.dart` and `lib/widgets/screens/settings_screen.dart`.
- Regenerate Rinf bindings and keep code formatted.

### Testing
- Ran `flutter pub get` to resolve dependencies and it completed successfully.
- Ran `just gen` to regenerate Rinf Dart bindings and it completed successfully.
- Ran `dart format` on the modified files and it completed successfully.
- Ran `flutter analyze` on `lib/main.dart`, `lib/widgets/screens/local_sideload_screen.dart`, and `lib/widgets/screens/settings_screen.dart` and there were no issues; a full-project `flutter analyze` had failing diagnostics prior to regenerating bindings due to missing/generated bindings but the touched files were validated after generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2b704aa188324a80f63d56d4971f5)